### PR TITLE
Update xor_doc.cxx

### DIFF
--- a/xor_doc.cxx
+++ b/xor_doc.cxx
@@ -33,8 +33,8 @@ int main(int argc, char **argv) {
 			std::cerr << "Not a XOR-ciphered doc file. fObfuscated=" << fObfuscated << " fEncrypted=" << fEncrypted << std::endl;  
 		}
 
-		unsigned short nKey = data[0x211] * 256 + data[0x210];
-		unsigned short nHash = data[0x20F] * 256 + data[0x20E];
+		unsigned short nKey = (unsigned char) data[0x211] * 256 + (unsigned char) data[0x210];
+		unsigned short nHash = (unsigned char) data[0x20F] * 256 + (unsigned char) data[0x20E];
 
 		std::cout << "nKey  " << std::hex << nKey << std::endl;
 		std::cout << "nHash " << std::hex << nHash << std::endl;


### PR DESCRIPTION
quand data[0x210] ou data[0x20E] sont >= à 0x80, mon système les considère comme signés et fait donc une soustraction plutôt qu'une addition. 
Exemple avec data[0x211] = 0xCC et data[0x210] = "0x94", data[0x211] \* 256+data[0x210] = 0xCC \* 0x100 + 0x6C = 0xCC00 + 0x6C... = 0xCB94 ! (alors qu'on doit obtenir 0xCC94).
